### PR TITLE
Split the single SSDP socket into two

### DIFF
--- a/src/ssdp/mod.rs
+++ b/src/ssdp/mod.rs
@@ -22,13 +22,19 @@ pub mod listener;
 pub mod packet;
 pub mod utils;
 
-pub static DUMMY_ADDRESS: (Ipv4Addr, u16) = (Ipv4Addr::new(0, 0, 0, 0), 1900);
+// Listen socket binds to port 1900 to receive M-SEARCH queries
+pub static LISTEN_ADDRESS: (Ipv4Addr, u16) = (Ipv4Addr::new(0, 0, 0, 0), 1900);
+
+// Broadcast socket uses ephemeral port - some clients/network equipment
+// ignore NOTIFY packets originating from port 1900
+pub static BROADCAST_ADDRESS: (Ipv4Addr, u16) = (Ipv4Addr::new(0, 0, 0, 0), 0);
 
 pub static SSDP_ADDRESS: (Ipv4Addr, u16) = (Ipv4Addr::new(239, 255, 255, 250), 1900);
 
 pub struct SSDPManager {
     broadcast_period: Duration,
-    socket: Arc<UdpSocket>,
+    listen_socket: Arc<UdpSocket>,
+    broadcast_socket: Arc<UdpSocket>,
     interactive_ssdp: Arc<InteractiveSSDP>,
     broadcaster: Arc<SSDPBroadcast>,
 }
@@ -48,7 +54,7 @@ impl SSDPManager {
 
         let http_client = http_client.build().context("Failed to build HTTP client")?;
 
-        let socket = ssdp_socket(broadcast_iface).await?;
+        let (listen_socket, broadcast_socket) = ssdp_sockets(broadcast_iface).await?;
 
         let cache_max_age = match broadcast_period.as_secs() {
             n if n < 20 => 20,
@@ -61,42 +67,57 @@ impl SSDPManager {
             cache_max_age,
         ));
 
-        let broadcaster = Arc::new(SSDPBroadcast::new(socket.clone(), interactive_ssdp.clone()));
+        let broadcaster = Arc::new(SSDPBroadcast::new(broadcast_socket.clone(), interactive_ssdp.clone()));
 
         Ok(SSDPManager {
             broadcast_period,
-            socket,
+            listen_socket,
+            broadcast_socket,
             interactive_ssdp,
             broadcaster,
         })
     }
 }
 
-async fn ssdp_socket(broadcast_iface: Option<String>) -> Result<Arc<UdpSocket>> {
-    let ssdp1 = UdpSocket::bind(DUMMY_ADDRESS)
+async fn ssdp_sockets(broadcast_iface: Option<String>) -> Result<(Arc<UdpSocket>, Arc<UdpSocket>)> {
+    // Listen socket on port 1900 for M-SEARCH queries
+    let listen_socket = UdpSocket::bind(LISTEN_ADDRESS)
         .await
-        .context("Failed to bind SSDP socket")?;
+        .context("Failed to bind SSDP listen socket")?;
 
-    socket::setsockopt(&ssdp1.as_fd(), ReuseAddr, &true).context("Failed to set SO_REUSEADDR.")?;
+    socket::setsockopt(&listen_socket.as_fd(), ReuseAddr, &true)
+        .context("Failed to set SO_REUSEADDR on listen socket.")?;
+
+    // Broadcast socket on ephemeral port for NOTIFY announcements
+    let broadcast_socket = UdpSocket::bind(BROADCAST_ADDRESS)
+        .await
+        .context("Failed to bind SSDP broadcast socket")?;
 
     if let Some(_iface) = broadcast_iface {
         #[cfg(any(target_os = "android", target_os = "linux"))]
         {
             let iface: std::ffi::OsString = std::ffi::OsString::from(_iface);
 
-            socket::setsockopt(&ssdp1.as_fd(), BindToDevice, &iface)
-                .context("Failed to set SO_BINDTODEVICE.")?;
+            socket::setsockopt(&listen_socket.as_fd(), BindToDevice, &iface)
+                .context("Failed to set SO_BINDTODEVICE on listen socket.")?;
+
+            socket::setsockopt(&broadcast_socket.as_fd(), BindToDevice, &iface)
+                .context("Failed to set SO_BINDTODEVICE on broadcast socket.")?;
         }
 
         #[cfg(target_os = "macos")]
         panic!("Cannot set broadcast address on MacOS (yet)")
     }
 
-    ssdp1
+    listen_socket
         .join_multicast_v4(SSDP_ADDRESS.0, Ipv4Addr::UNSPECIFIED)
-        .context("Failed to join SSDP multicast group.")?;
+        .context("Failed to join SSDP multicast group on listen socket.")?;
 
-    Ok(Arc::new(ssdp1))
+    broadcast_socket
+        .join_multicast_v4(SSDP_ADDRESS.0, Ipv4Addr::UNSPECIFIED)
+        .context("Failed to join SSDP multicast group on broadcast socket.")?;
+
+    Ok((Arc::new(listen_socket), Arc::new(broadcast_socket)))
 }
 
 pub async fn main_task(ssdp: SSDPManager) -> Result<()> {
@@ -105,15 +126,16 @@ pub async fn main_task(ssdp: SSDPManager) -> Result<()> {
     //We send an initial byebye before all else because... that's how MiniDLNA does it.
     //Guessing that it's for clearing any cache that might exist on listening remote devices.
     ssdp.interactive_ssdp
-        .send_byebye(&ssdp.socket, SSDP_ADDRESS)
+        .send_byebye(&ssdp.broadcast_socket, SSDP_ADDRESS)
         .await
         .context("Failed to send initial ssdp:byebye !")?;
 
     let _broadcast_handle =
         tokio::task::spawn(broadcast_task(ssdp.broadcaster, ssdp.broadcast_period));
 
+    // Listen task uses the socket bound to port 1900 to receive M-SEARCH queries
     let _listener_handle =
-        tokio::task::spawn(listen_task(ssdp.socket, ssdp.interactive_ssdp.clone()));
+        tokio::task::spawn(listen_task(ssdp.listen_socket, ssdp.interactive_ssdp.clone()));
 
     let _ = _listener_handle.await;
 


### PR DESCRIPTION
Some network equipment and DLNA clients ignore NOTIFY packets originating from port 1900, as this port is typically the destination for SSDP traffic, not the source. Other DLNA servers (like Emby) use random ephemeral source ports for their announcements. Binding to port 0 lets the OS assign a random ephemeral port.